### PR TITLE
Fix symbol validation in price forecast

### DIFF
--- a/backend/core.py
+++ b/backend/core.py
@@ -41,8 +41,18 @@ def upload_csv(file_storage):
     return {"message": f"File {file_storage.filename} uploaded successfully."}
 
 def get_predictions(symbol, days=30):
-    # Load stock data (OHLCV)
-    data_path = os.path.join(os.getcwd(), "backend", "data", f"{symbol}.csv")
+    """Return a naive price forecast for ``symbol``.
+
+    If ``symbol`` is missing or the CSV is unavailable, an error dict is
+    returned rather than raising an exception so the API can gracefully
+    handle invalid requests.
+    """
+    if not symbol:
+        return {"error": "Symbol not provided."}
+
+    # Allow passing either ``ABC`` or ``ABC.csv``
+    fname = symbol if symbol.lower().endswith(".csv") else f"{symbol}.csv"
+    data_path = os.path.join(os.getcwd(), "backend", "data", fname)
     if not os.path.exists(data_path):
         return {"error": "Stock data not found."}
     df = pd.read_csv(data_path)


### PR DESCRIPTION
## Summary
- handle missing or `.csv`-suffixed symbols in `get_predictions`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_687b36ecf6208325ac149d0f339d273a