### PR TITLE
Fix comment typo

### DIFF
--- a/app.py
+++ b/app.py
@@ -165,7 +165,7 @@ elif page == "Training & Forecast":
         except Exception as e:
             st.error(f"Forecast error: {e}")
 
-# --- Page 3: Strategy Execuation ---
+# --- Page 3: Strategy Execution ---
 elif page == "Strategy Execution":
     st.header("🤖 Automated Strategy Execution")
 


### PR DESCRIPTION
## Summary
- fix minor spelling mistake in strategy execution section comment

## Testing
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_687b389028288325bc072ddb058f4cf6